### PR TITLE
Add tmux availability check

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -83,6 +83,10 @@ func newTmuxSession(name string, program string, ptyFactory PtyFactory, cmdExec 
 // Start creates and starts a new tmux session, then attaches to it. Program is the command to run in
 // the session (ex. claude). workdir is the git worktree directory.
 func (t *TmuxSession) Start(workDir string) error {
+	// Ensure tmux is installed before attempting to start a session
+	if err := checkTmux(); err != nil {
+		return err
+	}
 	// Check if the session already exists
 	if t.DoesSessionExist() {
 		return fmt.Errorf("tmux session already exists: %s", t.sanitizedName)
@@ -157,6 +161,9 @@ func (t *TmuxSession) Start(workDir string) error {
 
 // Restore attaches to an existing session and restores the window size
 func (t *TmuxSession) Restore() error {
+	if err := checkTmux(); err != nil {
+		return err
+	}
 	ptmx, err := t.ptyFactory.Start(exec.Command("tmux", "attach-session", "-t", t.sanitizedName))
 	if err != nil {
 		return fmt.Errorf("error opening PTY: %w", err)

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -50,6 +50,8 @@ func TestSanitizeName(t *testing.T) {
 }
 
 func TestStartTmuxSession(t *testing.T) {
+	skipTmuxCheck = true
+	defer func() { skipTmuxCheck = false }()
 	ptyFactory := NewMockPtyFactory(t)
 
 	created := false

--- a/session/tmux/util.go
+++ b/session/tmux/util.go
@@ -1,0 +1,20 @@
+package tmux
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// skipTmuxCheck can be set in tests to bypass the tmux presence check.
+var skipTmuxCheck bool
+
+// checkTmux checks if tmux is installed and reachable in PATH.
+func checkTmux() error {
+	if skipTmuxCheck {
+		return nil
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		return fmt.Errorf("tmux is not installed or not in PATH: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- verify `tmux` exists in `TmuxSession.Start` and `TmuxSession.Restore`
- add helper `checkTmux` with a test hook
- update unit test to bypass tmux check

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68466254cab48329a17bc0264b52dca3