### PR TITLE
Improve tmux startup diagnostics

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -94,6 +94,9 @@ func (t *TmuxSession) Start(workDir string) error {
 
 	// Create a new detached tmux session and start claude in it
 	cmd := exec.Command("tmux", "new-session", "-d", "-s", t.sanitizedName, "-c", workDir, t.program)
+	if log.InfoLog != nil {
+		log.InfoLog.Printf("starting tmux session with PATH=%s cmd=%s", os.Getenv("PATH"), cmd.String())
+	}
 
 	ptmx, err := t.ptyFactory.Start(cmd)
 	if err != nil {
@@ -164,7 +167,11 @@ func (t *TmuxSession) Restore() error {
 	if err := checkTmux(); err != nil {
 		return err
 	}
-	ptmx, err := t.ptyFactory.Start(exec.Command("tmux", "attach-session", "-t", t.sanitizedName))
+	cmd := exec.Command("tmux", "attach-session", "-t", t.sanitizedName)
+	if log.InfoLog != nil {
+		log.InfoLog.Printf("restoring tmux session with PATH=%s cmd=%s", os.Getenv("PATH"), cmd.String())
+	}
+	ptmx, err := t.ptyFactory.Start(cmd)
 	if err != nil {
 		return fmt.Errorf("error opening PTY: %w", err)
 	}

--- a/session/tmux/util.go
+++ b/session/tmux/util.go
@@ -2,7 +2,10 @@ package tmux
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+
+	"claude-squad/log"
 )
 
 // skipTmuxCheck can be set in tests to bypass the tmux presence check.
@@ -13,8 +16,16 @@ func checkTmux() error {
 	if skipTmuxCheck {
 		return nil
 	}
-	if _, err := exec.LookPath("tmux"); err != nil {
+	pathEnv := os.Getenv("PATH")
+	tmuxPath, err := exec.LookPath("tmux")
+	if err != nil {
+		if log.ErrorLog != nil {
+			log.ErrorLog.Printf("tmux not found in PATH: %s", pathEnv)
+		}
 		return fmt.Errorf("tmux is not installed or not in PATH: %w", err)
+	}
+	if log.InfoLog != nil {
+		log.InfoLog.Printf("tmux found at %s (PATH=%s)", tmuxPath, pathEnv)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- log tmux path discovery in `checkTmux`
- log PATH and command when starting or restoring a tmux session

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68466b8d6008832998f66e5ee465e93d