### PR TITLE
Improve tmux session restore

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -6,6 +6,7 @@ import (
 	"claude-squad/session/tmux"
 	"path/filepath"
 
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -218,8 +219,15 @@ func (i *Instance) Start(firstTimeSetup bool) error {
 	if !firstTimeSetup {
 		// Reuse existing session
 		if err := tmuxSession.Restore(); err != nil {
-			setupErr = fmt.Errorf("failed to restore existing session: %w", err)
-			return setupErr
+			if errors.Is(err, tmux.ErrSessionNotExist) {
+				if err := i.tmuxSession.Start(i.gitWorktree.GetWorktreePath()); err != nil {
+					setupErr = fmt.Errorf("failed to start new session: %w", err)
+					return setupErr
+				}
+			} else {
+				setupErr = fmt.Errorf("failed to restore existing session: %w", err)
+				return setupErr
+			}
 		}
 	} else {
 		// Setup git worktree first

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -58,6 +58,10 @@ type TmuxSession struct {
 
 const TmuxPrefix = "claudesquad_"
 
+// ErrSessionNotExist is returned when Restore is called for a session that does
+// not exist.
+var ErrSessionNotExist = errors.New("tmux session does not exist")
+
 var whiteSpaceRegex = regexp.MustCompile(`\s+`)
 
 func toClaudeSquadTmuxName(str string) string {
@@ -166,6 +170,10 @@ func (t *TmuxSession) Start(workDir string) error {
 func (t *TmuxSession) Restore() error {
 	if err := checkTmux(); err != nil {
 		return err
+	}
+
+	if !t.DoesSessionExist() {
+		return ErrSessionNotExist
 	}
 
 	cmd := exec.Command("tmux", "attach-session", "-t", t.sanitizedName)

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -88,3 +88,24 @@ func TestStartTmuxSession(t *testing.T) {
 	_, err = ptyFactory.files[1].Stat()
 	require.NoError(t, err)
 }
+
+func TestRestoreMissingSession(t *testing.T) {
+	skipTmuxCheck = true
+	defer func() { skipTmuxCheck = false }()
+
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") {
+				return fmt.Errorf("session missing")
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession("test-session", "claude", ptyFactory, cmdExec)
+	err := session.Restore()
+	require.ErrorIs(t, err, ErrSessionNotExist)
+	require.Equal(t, 0, len(ptyFactory.cmds))
+}


### PR DESCRIPTION
## Summary
- expose `ErrSessionNotExist` from tmux
- check for session before running `tmux attach-session`
- recreate tmux session when `Restore` fails due to missing session
- test that `Restore` fails with `ErrSessionNotExist`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684677f78b508329976322865cb3aba1